### PR TITLE
fix: use flat style for GitHub stars badge to match other badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/charannyk06/ChainReview/stargazers"><img src="https://img.shields.io/github/stars/charannyk06/ChainReview?style=social&label=GitHub%20Stars&color=6366f1" alt="GitHub Stars" /></a>
+  <a href="https://github.com/charannyk06/ChainReview/stargazers"><img src="https://img.shields.io/github/stars/charannyk06/ChainReview?style=flat&color=6366f1&labelColor=0f0f0f" alt="GitHub Stars" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=chainreview.chainreview"><img src="https://img.shields.io/badge/VS%20Code-Install-6366f1?style=flat&labelColor=0f0f0f&logo=visualstudiocode" alt="VS Code" /></a>
   <a href="https://github.com/charannyk06/ChainReview/blob/main/LICENSE"><img src="https://img.shields.io/github/license/charannyk06/ChainReview?style=flat&color=6366f1&labelColor=0f0f0f" alt="License" /></a>
   <a href="https://github.com/charannyk06/ChainReview/issues"><img src="https://img.shields.io/github/issues/charannyk06/ChainReview?style=flat&color=6366f1&labelColor=0f0f0f" alt="Issues" /></a>


### PR DESCRIPTION
## Summary

- The GitHub stars badge was using `style=social` which ignores the `color` parameter, so the brand color `#6366f1` had no effect
- Updated to `style=flat&color=6366f1&labelColor=0f0f0f` to match the VS Code, License, and Issues badges for a consistent look

## Before / After

| Before | After |
|---|---|
| `style=social` (color ignored, different look) | `style=flat&color=6366f1&labelColor=0f0f0f` (brand color applied, matches other badges) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub Stars badge styling in the README for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->